### PR TITLE
v1.1 UI Polish: Rename 'Wasted' to 'Unused' and add tooltips

### DIFF
--- a/frontend/src/components/MetricScorecard.jsx
+++ b/frontend/src/components/MetricScorecard.jsx
@@ -3,6 +3,7 @@
 
 import React from 'react';
 import { TrendingUp, TrendingDown, Minus, ArrowRight } from 'lucide-react';
+import Tooltip from './Tooltip';
 
 const MetricScorecard = ({
   label,
@@ -14,6 +15,7 @@ const MetricScorecard = ({
   thresholds = { warning: 75, critical: 85 },
   showBar = false,
   max = 100,
+  tooltip = null,
 }) => {
   const change = proposedValue - currentValue;
   const changePercent = currentValue !== 0 ? (change / currentValue) * 100 : 0;
@@ -55,7 +57,13 @@ const MetricScorecard = ({
     <div className="bg-slate-800/50 backdrop-blur-sm rounded-lg p-4 border border-slate-700/50 hover:border-slate-600/50 transition-colors">
       {/* Label */}
       <div className="text-xs uppercase tracking-wider text-gray-400 font-medium mb-3">
-        {label}
+        {tooltip ? (
+          <Tooltip text={tooltip} position="top" showIcon>
+            {label}
+          </Tooltip>
+        ) : (
+          label
+        )}
       </div>
 
       {/* Values row */}

--- a/frontend/src/components/ScenarioResults.jsx
+++ b/frontend/src/components/ScenarioResults.jsx
@@ -5,7 +5,21 @@ import React from 'react';
 import { CheckCircle2, XCircle, AlertTriangle, Zap, HardDrive, Cpu, Server, Shield, Activity, Database, Gauge } from 'lucide-react';
 import CapacityGauge from './CapacityGauge';
 import MetricScorecard from './MetricScorecard';
+import Tooltip from './Tooltip';
 import { TPS_STATUS_COLORS, TPS_STATUS_BG_COLORS } from '../config/resourceConfig';
+
+const TOOLTIPS = {
+  n1Capacity: "Utilization if you lose one cell (host failure scenario). Below 75% = safe headroom. Above 85% = cannot survive cell loss.",
+  memoryUtilization: "App memory divided by total cell capacity. Below 80% = healthy headroom. Above 90% = near capacity exhaustion.",
+  diskUtilization: "App disk usage divided by total cell disk capacity. Same thresholds as memory.",
+  stagingCapacity: "Available 4GB chunks for staging new apps. When you cf push, Diego needs a 4GB chunk to build your app. Low chunks = deployment queues.",
+  tps: "Tasks Per Second - how fast Diego's scheduler can place app instances. Higher = faster deploys and scaling.",
+  tpsStatus: "Optimal (≥80% of peak): scheduler performing well. Degraded (50-79%): noticeable slowdown. Critical (<50%): severe delays.",
+  cellCount: "Number of Diego cell VMs running your apps.",
+  appCapacity: "Total memory available for apps after system overhead.",
+  faultImpact: "Average app instances displaced if one cell fails. Lower = smaller blast radius.",
+  instancesPerCell: "Average app instances per cell. Lower = more distributed workload.",
+};
 
 const ScenarioResults = ({ comparison, warnings = [], selectedResources = ['memory'] }) => {
   if (!comparison) return null;
@@ -82,7 +96,9 @@ const ScenarioResults = ({ comparison, warnings = [], selectedResources = ['memo
         <div className="bg-slate-800/30 rounded-xl p-6 border border-slate-700/50">
           <div className="flex items-center gap-2 mb-4 text-gray-400">
             <Shield size={16} />
-            <span className="text-xs uppercase tracking-wider font-medium">N-1 Capacity</span>
+            <Tooltip text={TOOLTIPS.n1Capacity} position="bottom" showIcon>
+              <span className="text-xs uppercase tracking-wider font-medium">N-1 Capacity</span>
+            </Tooltip>
           </div>
           <CapacityGauge
             value={proposed.n1_utilization_pct}
@@ -99,7 +115,9 @@ const ScenarioResults = ({ comparison, warnings = [], selectedResources = ['memo
         <div className="bg-slate-800/30 rounded-xl p-6 border border-slate-700/50">
           <div className="flex items-center gap-2 mb-4 text-gray-400">
             <Activity size={16} />
-            <span className="text-xs uppercase tracking-wider font-medium">Memory Utilization</span>
+            <Tooltip text={TOOLTIPS.memoryUtilization} position="bottom" showIcon>
+              <span className="text-xs uppercase tracking-wider font-medium">Memory Utilization</span>
+            </Tooltip>
           </div>
           <CapacityGauge
             value={proposed.utilization_pct}
@@ -117,7 +135,9 @@ const ScenarioResults = ({ comparison, warnings = [], selectedResources = ['memo
           <div className="bg-slate-800/30 rounded-xl p-6 border border-slate-700/50">
             <div className="flex items-center gap-2 mb-4 text-gray-400">
               <Database size={16} />
-              <span className="text-xs uppercase tracking-wider font-medium">Disk Utilization</span>
+              <Tooltip text={TOOLTIPS.diskUtilization} position="bottom" showIcon>
+                <span className="text-xs uppercase tracking-wider font-medium">Disk Utilization</span>
+              </Tooltip>
             </div>
             <CapacityGauge
               value={proposed.disk_utilization_pct}
@@ -135,7 +155,9 @@ const ScenarioResults = ({ comparison, warnings = [], selectedResources = ['memo
         <div className="bg-slate-800/30 rounded-xl p-6 border border-slate-700/50">
           <div className="flex items-center gap-2 mb-4 text-gray-400">
             <Zap size={16} />
-            <span className="text-xs uppercase tracking-wider font-medium">Staging Capacity</span>
+            <Tooltip text={TOOLTIPS.stagingCapacity} position="bottom" showIcon>
+              <span className="text-xs uppercase tracking-wider font-medium">Staging Capacity</span>
+            </Tooltip>
           </div>
           <CapacityGauge
             value={Math.min((proposed.free_chunks / 800) * 100, 100)}
@@ -155,7 +177,9 @@ const ScenarioResults = ({ comparison, warnings = [], selectedResources = ['memo
         <div className="bg-slate-800/30 rounded-xl p-6 border border-slate-700/50">
           <div className="flex items-center gap-2 mb-4 text-gray-400">
             <Gauge size={16} />
-            <span className="text-xs uppercase tracking-wider font-medium">Scheduling Performance (TPS)</span>
+            <Tooltip text={TOOLTIPS.tps} position="bottom" showIcon>
+              <span className="text-xs uppercase tracking-wider font-medium">Scheduling Performance (TPS)</span>
+            </Tooltip>
           </div>
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-6">
@@ -212,6 +236,7 @@ const ScenarioResults = ({ comparison, warnings = [], selectedResources = ['memo
           icon={Server}
           inverse={false}
           thresholds={{ warning: 0, critical: 0 }}
+          tooltip={TOOLTIPS.cellCount}
         />
         <MetricScorecard
           label="App Capacity"
@@ -221,6 +246,7 @@ const ScenarioResults = ({ comparison, warnings = [], selectedResources = ['memo
           unit="B"
           inverse={false}
           thresholds={{ warning: 0, critical: 0 }}
+          tooltip={TOOLTIPS.appCapacity}
         />
         <MetricScorecard
           label="Fault Impact"
@@ -229,6 +255,7 @@ const ScenarioResults = ({ comparison, warnings = [], selectedResources = ['memo
           unit=" apps/cell"
           inverse={true}
           thresholds={{ warning: 25, critical: 50 }}
+          tooltip={TOOLTIPS.faultImpact}
         />
         <MetricScorecard
           label="Instances/Cell"
@@ -237,6 +264,7 @@ const ScenarioResults = ({ comparison, warnings = [], selectedResources = ['memo
           format={(v) => v.toFixed(1)}
           inverse={true}
           thresholds={{ warning: 30, critical: 50 }}
+          tooltip={TOOLTIPS.instancesPerCell}
         />
       </div>
 

--- a/frontend/src/components/Tooltip.jsx
+++ b/frontend/src/components/Tooltip.jsx
@@ -1,0 +1,47 @@
+// ABOUTME: Lightweight tooltip component using CSS-only approach
+// ABOUTME: Displays help text on hover with configurable positioning
+
+import React from 'react';
+import { HelpCircle } from 'lucide-react';
+
+const Tooltip = ({ text, children, position = 'top', showIcon = false }) => {
+  const positionClasses = {
+    top: 'bottom-full left-1/2 -translate-x-1/2 mb-2',
+    bottom: 'top-full left-1/2 -translate-x-1/2 mt-2',
+    left: 'right-full top-1/2 -translate-y-1/2 mr-2',
+    right: 'left-full top-1/2 -translate-y-1/2 ml-2',
+  };
+
+  const arrowClasses = {
+    top: 'top-full left-1/2 -translate-x-1/2 border-t-slate-700 border-x-transparent border-b-transparent',
+    bottom: 'bottom-full left-1/2 -translate-x-1/2 border-b-slate-700 border-x-transparent border-t-transparent',
+    left: 'left-full top-1/2 -translate-y-1/2 border-l-slate-700 border-y-transparent border-r-transparent',
+    right: 'right-full top-1/2 -translate-y-1/2 border-r-slate-700 border-y-transparent border-l-transparent',
+  };
+
+  return (
+    <span className="relative inline-flex items-center group">
+      {children}
+      {showIcon && (
+        <HelpCircle size={12} className="ml-1 text-slate-500 group-hover:text-slate-400 transition-colors" />
+      )}
+      <span
+        className={`
+          absolute z-50 ${positionClasses[position]}
+          px-3 py-2 text-xs text-slate-200 bg-slate-700 rounded-lg shadow-lg
+          opacity-0 invisible group-hover:opacity-100 group-hover:visible
+          transition-all duration-200 ease-out
+          min-w-[200px] max-w-[280px] whitespace-normal text-center
+          pointer-events-none
+        `}
+      >
+        {text}
+        <span
+          className={`absolute border-4 ${arrowClasses[position]}`}
+        />
+      </span>
+    </span>
+  );
+};
+
+export default Tooltip;


### PR DESCRIPTION
## Summary

- Rename "Wasted Memory" to "Unused Memory" throughout the UI (#11)
- Add hover tooltips to capacity gauges and metrics (#9)

## Changes

### Terminology Fix (#11)
- Renamed `wastedMemory` → `unusedMemory` in code
- Updated UI label from "Wasted Memory" to "Unused Memory"
- Changed icon color from red to amber (less alarming for what's actually just headroom)

### Tooltips (#9)
- Created reusable `Tooltip` component using CSS-only hover (no new dependencies)
- Added tooltips to Dashboard metric cards (Total Cells, Utilization, Avg CPU, Unused Memory)
- Added tooltips to Scenario Analysis gauges (N-1 Capacity, Memory Utilization, Disk Utilization, Staging Capacity)
- Added tooltips to TPS performance section
- Added tooltip prop to MetricScorecard component

## Test plan

- [ ] Verify "Unused Memory" displays correctly on Dashboard
- [ ] Hover over metric labels to confirm tooltips appear
- [ ] Check tooltip positioning doesn't overflow viewport edges
- [ ] Test on Scenario Analysis tab gauges and scorecards

Closes #9, closes #11