### PR TITLE
Fix N-1 capacity messaging to clarify host vs cell failure

### DIFF
--- a/frontend/src/components/ScenarioResults.jsx
+++ b/frontend/src/components/ScenarioResults.jsx
@@ -9,7 +9,7 @@ import Tooltip from './Tooltip';
 import { TPS_STATUS_COLORS, TPS_STATUS_BG_COLORS } from '../config/resourceConfig';
 
 const TOOLTIPS = {
-  n1Capacity: "Utilization if you lose one cell (host failure scenario). Below 75% = safe headroom. Above 85% = cannot survive cell loss.",
+  n1Capacity: "Infrastructure utilization vs N-1 host capacity. If one ESXi host fails, can the remaining hosts run all Diego cell and platform VMs? Below 75% = safe. Above 85% = at risk of capacity exhaustion after host failure.",
   memoryUtilization: "App memory divided by total cell capacity. Below 80% = healthy headroom. Above 90% = near capacity exhaustion.",
   diskUtilization: "App disk usage divided by total cell disk capacity. Same thresholds as memory.",
   stagingCapacity: "Available 4GB chunks for staging new apps. When you cf push, Diego needs a 4GB chunk to build your app. Low chunks = deployment queues.",


### PR DESCRIPTION
## Summary
- Fixed the N-1 Capacity tooltip to accurately describe what N-1 protection means
- N-1 is about **ESXi host** failure, not Diego cell failure

## Problem
The tooltip incorrectly stated: "Utilization if you lose one cell (host failure scenario)... cannot survive cell loss"

This conflated two different failure modes:
1. **N-1 Host Protection** - Can vSphere HA restart all VMs if one ESXi host fails?
2. **Fault Impact** - How many app instances are displaced if one Diego cell crashes?

## Changes
Updated tooltip to:
> "Infrastructure utilization vs N-1 host capacity. If one ESXi host fails, can the remaining hosts run all Diego cell and platform VMs?"

## Also Updated (outside repo)
The MetricsRef.md document was also updated with:
- Corrected N-1 Capacity section explanation
- Fixed the N-1 formula to show it's based on host count, not cell count
- Added clarification distinguishing N-1 (host-level) from Fault Impact (cell-level)

## Test plan
- [x] Frontend tests pass (27/27)
- [x] Frontend build succeeds
- [x] Verify tooltip displays correctly in UI