### PR TITLE
v1.3 - Add structured logging with log/slog

### DIFF
--- a/backend/logger/logger.go
+++ b/backend/logger/logger.go
@@ -1,0 +1,45 @@
+// ABOUTME: Structured logging configuration using log/slog.
+// ABOUTME: Provides Init() to configure default logger with level and format from environment.
+
+package logger
+
+import (
+	"log/slog"
+	"os"
+	"strings"
+)
+
+// Init configures the default slog logger based on environment variables.
+// LOG_LEVEL: debug, info, warn, error (default: info)
+// LOG_FORMAT: text, json (default: text)
+func Init() {
+	level := parseLevel(os.Getenv("LOG_LEVEL"))
+	format := strings.ToLower(os.Getenv("LOG_FORMAT"))
+
+	opts := &slog.HandlerOptions{
+		Level: level,
+	}
+
+	var handler slog.Handler
+	if format == "json" {
+		handler = slog.NewJSONHandler(os.Stdout, opts)
+	} else {
+		handler = slog.NewTextHandler(os.Stdout, opts)
+	}
+
+	slog.SetDefault(slog.New(handler))
+}
+
+// parseLevel converts a string log level to slog.Level.
+func parseLevel(level string) slog.Level {
+	switch strings.ToLower(level) {
+	case "debug":
+		return slog.LevelDebug
+	case "warn", "warning":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}

--- a/backend/middleware/logging.go
+++ b/backend/middleware/logging.go
@@ -1,0 +1,60 @@
+// ABOUTME: HTTP request logging middleware with correlation IDs.
+// ABOUTME: Logs request start/end with method, path, status, and latency.
+
+package middleware
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+// responseWriter wraps http.ResponseWriter to capture the status code.
+type responseWriter struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func (rw *responseWriter) WriteHeader(code int) {
+	rw.statusCode = code
+	rw.ResponseWriter.WriteHeader(code)
+}
+
+// LogRequest logs HTTP requests with timing and correlation ID.
+func LogRequest(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		requestID := generateRequestID()
+
+		// Add request ID to response header
+		w.Header().Set("X-Request-ID", requestID)
+
+		slog.Info("Request started",
+			"request_id", requestID,
+			"method", r.Method,
+			"path", r.URL.Path,
+		)
+
+		// Wrap response writer to capture status
+		wrapped := &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+
+		next(wrapped, r)
+
+		slog.Info("Request completed",
+			"request_id", requestID,
+			"method", r.Method,
+			"path", r.URL.Path,
+			"status", wrapped.statusCode,
+			"latency_ms", time.Since(start).Milliseconds(),
+		)
+	}
+}
+
+// generateRequestID creates a short random hex ID.
+func generateRequestID() string {
+	b := make([]byte, 8)
+	rand.Read(b)
+	return hex.EncodeToString(b)
+}

--- a/backend/services/logcache.go
+++ b/backend/services/logcache.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
@@ -125,6 +126,7 @@ func (l *LogCacheClient) GetAppMemoryMetrics(appGUID string) (*AppMetrics, error
 	}
 
 	if count == 0 {
+		slog.Debug("Log Cache returned no memory metrics", "app_guid", appGUID)
 		return &AppMetrics{
 			GUID:           appGUID,
 			MemoryBytesAvg: 0,
@@ -133,12 +135,14 @@ func (l *LogCacheClient) GetAppMemoryMetrics(appGUID string) (*AppMetrics, error
 		}, nil
 	}
 
-	return &AppMetrics{
+	metrics := &AppMetrics{
 		GUID:           appGUID,
 		MemoryBytesAvg: totalMemory / int64(count),
-		MemoryBytesCur: totalMemory / int64(len(instancesSeen)), // Latest per instance
+		MemoryBytesCur: totalMemory / int64(len(instancesSeen)),
 		InstanceCount:  len(instancesSeen),
-	}, nil
+	}
+	slog.Debug("Log Cache metrics retrieved", "app_guid", appGUID, "avg_bytes", metrics.MemoryBytesAvg, "instances", metrics.InstanceCount)
+	return metrics, nil
 }
 
 // GetAppMemoryPromQL uses PromQL endpoint for more precise queries

--- a/backend/services/vsphere.go
+++ b/backend/services/vsphere.go
@@ -6,7 +6,7 @@ package services
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/url"
 	"strings"
 	"time"
@@ -92,6 +92,7 @@ func (v *VSphereClient) Connect(ctx context.Context) error {
 	v.datacenter = dc
 	v.finder.SetDatacenter(dc)
 
+	slog.Info("vSphere connected", "host", v.creds.Host, "datacenter", v.creds.Datacenter)
 	return nil
 }
 
@@ -314,7 +315,7 @@ func (v *VSphereClient) GetInfrastructureState(ctx context.Context) (models.Infr
 		return models.InfrastructureState{}, fmt.Errorf("getting Diego cells: %w", err)
 	}
 
-	log.Printf("[vSphere] Found %d Diego cells total in datacenter", len(allCells))
+	slog.Info("vSphere Diego cell discovery complete", "cell_count", len(allCells), "datacenter", v.creds.Datacenter)
 
 	state := models.InfrastructureState{
 		Source:    "vsphere",


### PR DESCRIPTION
## Summary

Implements structured logging for the Go backend using the standard library's `log/slog` package, addressing #7.

**Changes:**
- New `logger/` package for slog initialization with environment-based configuration
- New `middleware/` package for HTTP request logging with correlation IDs
- Converted all existing `log.Printf/Println` calls to structured slog equivalents
- Added logging to services that previously had none (CF API, Log Cache)

**Environment Variables:**
| Variable | Values | Default |
|----------|--------|---------|
| `LOG_LEVEL` | debug, info, warn, error | info |
| `LOG_FORMAT` | text, json | text |

**Example Output (text format):**
```
time=2024-12-22T15:00:00Z level=INFO msg="Starting Diego Capacity Analyzer Backend"
time=2024-12-22T15:00:00Z level=INFO msg="Request started" request_id=abc123 method=GET path=/api/dashboard
time=2024-12-22T15:00:00Z level=INFO msg="Request completed" request_id=abc123 status=200 latency_ms=234
```

## Test plan

- [x] Backend builds successfully
- [x] All existing tests pass
- [ ] Verify logs appear with `LOG_LEVEL=debug`
- [ ] Verify JSON output with `LOG_FORMAT=json`
- [ ] Verify X-Request-ID header in responses

Closes #7