### PR TITLE
Add portable generate-env.sh script for deriving credentials from Ops Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ cf.yml
 bosh-*.yml.envrc
 bosh-*.yml
 settings.local.json
+setup-env.sh

--- a/README.md
+++ b/README.md
@@ -6,17 +6,11 @@ A professional dashboard for analyzing Tanzu Application Service (TAS) / Diego c
 ![React](https://img.shields.io/badge/react-18.2-blue.svg)
 ![License](https://img.shields.io/github/license/malston/diego-capacity-analyzer)
 
-## Screenshots
-
-### Dashboard
-![Dashboard showing real-time capacity metrics and Diego cells](docs/images/dashboard.gif)
-
-### Capacity Planning
-![Capacity Planning wizard with scenario analysis](docs/images/capacity-planning.gif)
-
 ## Features
 
 ### Dashboard
+
+![Dashboard showing real-time capacity metrics and Diego cells](docs/images/dashboard.gif)
 
 - **Real-time Capacity Monitoring** - Track Diego cell memory, CPU, and utilization across all cells
 - **Isolation Segment Filtering** - View metrics by isolation segment
@@ -24,6 +18,8 @@ A professional dashboard for analyzing Tanzu Application Service (TAS) / Diego c
 - **Right-Sizing Recommendations** - Identify over-provisioned apps with specific memory recommendations
 
 ### Capacity Planning
+
+![Capacity Planning wizard with scenario analysis](docs/images/capacity-planning.gif)
 
 - **Scenario Analysis Wizard** - Step-based configuration: Resources → Cell Config → CPU Config → Host Config → Advanced
 - **vSphere Infrastructure Discovery** - Live infrastructure data from vCenter
@@ -79,10 +75,42 @@ POST /api/scenario/compare          # Compare current vs proposed scenarios
 
 ## Configuration
 
-### Required Environment Variables
+### Generating Configuration from Ops Manager
+
+If you have access to an Ops Manager, use `generate-env.sh` to automatically derive all credentials:
 
 ```bash
-# Cloud Foundry API
+# Option 1: Username/password authentication
+export OM_TARGET=opsman.example.com
+export OM_USERNAME=admin
+export OM_PASSWORD=<your-password>
+
+# Option 2: OAuth client credentials
+export OM_TARGET=opsman.example.com
+export OM_CLIENT_ID=<client-id>
+export OM_CLIENT_SECRET=<client-secret>
+
+# Optional: SSH key for non-routable BOSH networks (tunnels through Ops Manager)
+export OM_PRIVATE_KEY=~/.ssh/opsman_key
+
+# Generate .env file with all derived credentials
+./generate-env.sh
+```
+
+The script connects to Ops Manager and derives:
+
+- BOSH Director credentials and CA certificate
+- CF API credentials and system domain
+- vSphere host, datacenter, and credentials
+- CredHub configuration
+
+### Manual Configuration
+
+If not using Ops Manager, set environment variables manually:
+
+#### Required: Cloud Foundry API
+
+```bash
 export CF_API_URL=https://api.sys.example.com
 export CF_USERNAME=admin
 export CF_PASSWORD=secret
@@ -189,7 +217,8 @@ GitHub Actions workflows run automatically:
 │   └── manifest.yml            # CF deployment manifest
 │
 ├── .github/workflows/          # CI/CD pipelines
-└── docs/                       # Documentation
+├── docs/                       # Documentation
+└── generate-env.sh             # Generate .env from Ops Manager
 ```
 
 ## Technology Stack

--- a/generate-env.sh
+++ b/generate-env.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# ABOUTME: Generates .env file by deriving credentials from Ops Manager and BOSH.
+# ABOUTME: Requires OM_TARGET and either username/password or client credentials.
+
+set -euo pipefail
+
+# Check required variable
+if [[ -z "${OM_TARGET:-}" ]]; then
+    echo "Error: OM_TARGET is required." >&2
+    echo "" >&2
+    echo "Usage with username/password:" >&2
+    echo "  export OM_TARGET=opsman.example.com" >&2
+    echo "  export OM_USERNAME=admin" >&2
+    echo "  export OM_PASSWORD=<password>" >&2
+    echo "" >&2
+    echo "Usage with client credentials:" >&2
+    echo "  export OM_TARGET=opsman.example.com" >&2
+    echo "  export OM_CLIENT_ID=<client-id>" >&2
+    echo "  export OM_CLIENT_SECRET=<client-secret>" >&2
+    echo "" >&2
+    echo "Optional (for non-routable BOSH networks):" >&2
+    echo "  export OM_PRIVATE_KEY=~/.ssh/opsman_key" >&2
+    exit 1
+fi
+
+# Check authentication: need either username/password OR client credentials
+has_user_auth=false
+has_client_auth=false
+
+if [[ -n "${OM_USERNAME:-}" && -n "${OM_PASSWORD:-}" ]]; then
+    has_user_auth=true
+fi
+
+if [[ -n "${OM_CLIENT_ID:-}" && -n "${OM_CLIENT_SECRET:-}" ]]; then
+    has_client_auth=true
+fi
+
+if [[ "$has_user_auth" == "false" && "$has_client_auth" == "false" ]]; then
+    echo "Error: Missing authentication credentials." >&2
+    echo "Set either OM_USERNAME/OM_PASSWORD or OM_CLIENT_ID/OM_CLIENT_SECRET" >&2
+    exit 1
+fi
+
+# Optional: set to true to skip SSL validation (not recommended for production)
+export OM_SKIP_SSL_VALIDATION="${OM_SKIP_SSL_VALIDATION:-false}"
+
+# Export required vars for om CLI
+export OM_TARGET
+if [[ "$has_user_auth" == "true" ]]; then
+    export OM_USERNAME OM_PASSWORD
+fi
+if [[ "$has_client_auth" == "true" ]]; then
+    export OM_CLIENT_ID OM_CLIENT_SECRET
+fi
+
+eval "$(om bosh-env 2>/dev/null)"
+
+# Set up SSH proxy if private key is provided (for non-routable BOSH networks)
+if [[ -n "${OM_PRIVATE_KEY:-}" ]]; then
+    export BOSH_ALL_PROXY="ssh+socks5://ubuntu@$OM_TARGET:22?private-key=$OM_PRIVATE_KEY"
+fi
+
+export BOSH_DEPLOYMENT
+BOSH_DEPLOYMENT=$(bosh deployments --json | jq -r '.Tables[0].Rows[] | select(.name | startswith("cf-")) | .name')
+
+export CF_USERNAME=admin
+export CF_PASSWORD
+CF_PASSWORD=$(om credentials -p cf -c .uaa.admin_credentials -t json | jq -r '.password')
+CF_SYSTEM_DOMAIN=$(om curl -s --path /api/v0/staged/products/"$BOSH_DEPLOYMENT"/properties | jq -r '.properties.".cloud_controller.system_domain"' | jq -r '.value')
+
+VSPHERE_HOST=$(om curl -s --path /api/v0/staged/director/properties | jq -r '.iaas_configuration?.vcenter_host')
+VSPHERE_DATACENTER=$(om curl -s --path /api/v0/staged/director/properties | jq -r '.iaas_configuration?.datacenter')
+VSPHERE_USERNAME=$(om curl -s --path /api/v0/staged/director/properties | jq -r '.iaas_configuration?.vcenter_username')
+export VSPHERE_PASSWORD
+VSPHERE_PASSWORD=$(om staged-director-config --no-redact | yq '.iaas-configurations[].vcenter_password')
+
+cat > .env << EOF
+BOSH_CA_CERT="$BOSH_CA_CERT"
+BOSH_CLIENT=$BOSH_CLIENT
+BOSH_CLIENT_SECRET=$BOSH_CLIENT_SECRET
+BOSH_DEPLOYMENT=$BOSH_DEPLOYMENT
+BOSH_ENVIRONMENT=$BOSH_ENVIRONMENT
+EOF
+
+# Add proxy settings if configured (for non-routable BOSH networks)
+if [[ -n "${BOSH_ALL_PROXY:-}" ]]; then
+    cat >> .env << EOF
+BOSH_ALL_PROXY=$BOSH_ALL_PROXY
+EOF
+fi
+
+cat >> .env << EOF
+
+CF_API_URL=api.$CF_SYSTEM_DOMAIN
+CF_USERNAME=$CF_USERNAME
+CF_PASSWORD=$CF_PASSWORD
+
+CREDHUB_CA_CERT="$CREDHUB_CA_CERT"
+CREDHUB_CLIENT=$CREDHUB_CLIENT
+CREDHUB_SECRET=$CREDHUB_SECRET
+CREDHUB_SERVER=$CREDHUB_SERVER
+EOF
+
+if [[ -n "${BOSH_ALL_PROXY:-}" ]]; then
+    cat >> .env << EOF
+CREDHUB_PROXY=$BOSH_ALL_PROXY
+EOF
+fi
+
+cat >> .env << EOF
+
+OM_CONNECT_TIMEOUT=60
+OM_TARGET=$OM_TARGET
+OM_SKIP_SSL_VALIDATION=$OM_SKIP_SSL_VALIDATION
+EOF
+
+# Append auth credentials based on which method was used
+if [[ "$has_user_auth" == "true" ]]; then
+    cat >> .env << EOF
+OM_USERNAME=$OM_USERNAME
+OM_PASSWORD=$OM_PASSWORD
+EOF
+fi
+
+if [[ "$has_client_auth" == "true" ]]; then
+    cat >> .env << EOF
+OM_CLIENT_ID=$OM_CLIENT_ID
+OM_CLIENT_SECRET=$OM_CLIENT_SECRET
+EOF
+fi
+
+cat >> .env << EOF
+
+REACT_APP_CF_API_URL=https://api.$CF_SYSTEM_DOMAIN
+REACT_APP_CF_UAA_URL=https://login.$CF_SYSTEM_DOMAIN
+
+VITE_CF_API_URL=https://api.$CF_SYSTEM_DOMAIN
+VITE_CF_UAA_URL=https://login.$CF_SYSTEM_DOMAIN
+# Optional: BOSH Director URL (for diego cell metrics)
+VITE_BOSH_URL=https://$BOSH_ENVIRONMENT:25555
+
+VSPHERE_HOST=$VSPHERE_HOST
+VSPHERE_DATACENTER=$VSPHERE_DATACENTER
+VSPHERE_USERNAME=$VSPHERE_USERNAME
+VSPHERE_PASSWORD=$VSPHERE_PASSWORD
+EOF
+
+echo "Generated .env file with credentials for:"
+echo "  - BOSH Director: $BOSH_ENVIRONMENT"
+echo "  - CF Deployment: $BOSH_DEPLOYMENT"
+echo "  - CF API: api.$CF_SYSTEM_DOMAIN"
+echo "  - vSphere: $VSPHERE_HOST"


### PR DESCRIPTION
## Summary
- Create `generate-env.sh` that derives BOSH, CF, vSphere, and CredHub credentials from Ops Manager
- Support both username/password and OAuth client credentials authentication
- Make SSH proxy (`OM_PRIVATE_KEY`) optional for non-routable BOSH networks
- Update README with configuration documentation

## Test plan
- [ ] Test with username/password authentication
- [ ] Test with client credentials authentication
- [ ] Test without OM_PRIVATE_KEY (routable BOSH network)
- [ ] Test with OM_PRIVATE_KEY (non-routable BOSH network)
- [ ] Verify generated .env file contains correct credentials