### PR TITLE
feat(frontend): update API client to use /api/v1/ versioned endpoints

### DIFF
--- a/frontend/src/TASCapacityAnalyzer.jsx
+++ b/frontend/src/TASCapacityAnalyzer.jsx
@@ -41,7 +41,7 @@ const TASCapacityAnalyzer = () => {
 
     try {
       const apiURL = import.meta.env.VITE_API_URL || 'http://localhost:8080';
-      const response = await fetch(`${apiURL}/api/dashboard`);
+      const response = await fetch(`${apiURL}/api/v1/dashboard`);
 
       if (!response.ok) {
         throw new Error(`Backend returned ${response.status}`);

--- a/frontend/src/services/scenarioApi.js
+++ b/frontend/src/services/scenarioApi.js
@@ -11,7 +11,7 @@ export const scenarioApi = {
    * @returns {Promise<Object>} InfrastructureState
    */
   async setManualInfrastructure(data) {
-    const response = await fetch(`${API_URL}/api/infrastructure/manual`, {
+    const response = await fetch(`${API_URL}/api/v1/infrastructure/manual`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(data),
@@ -29,7 +29,7 @@ export const scenarioApi = {
    * @returns {Promise<Object>} ScenarioComparison
    */
   async compareScenario(input) {
-    const response = await fetch(`${API_URL}/api/scenario/compare`, {
+    const response = await fetch(`${API_URL}/api/v1/scenario/compare`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(input),
@@ -46,7 +46,7 @@ export const scenarioApi = {
    * @returns {Promise<Object>} InfrastructureState
    */
   async getLiveInfrastructure() {
-    const response = await fetch(`${API_URL}/api/infrastructure`, {
+    const response = await fetch(`${API_URL}/api/v1/infrastructure`, {
       method: 'GET',
       headers: { 'Content-Type': 'application/json' },
     });
@@ -62,7 +62,7 @@ export const scenarioApi = {
    * @returns {Promise<Object>} Status including vsphere_configured, has_data, source
    */
   async getInfrastructureStatus() {
-    const response = await fetch(`${API_URL}/api/infrastructure/status`, {
+    const response = await fetch(`${API_URL}/api/v1/infrastructure/status`, {
       method: 'GET',
       headers: { 'Content-Type': 'application/json' },
     });
@@ -78,7 +78,7 @@ export const scenarioApi = {
    * @returns {Promise<Object>} InfrastructureState
    */
   async setInfrastructureState(state) {
-    const response = await fetch(`${API_URL}/api/infrastructure/state`, {
+    const response = await fetch(`${API_URL}/api/v1/infrastructure/state`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(state),
@@ -96,7 +96,7 @@ export const scenarioApi = {
    * @returns {Promise<Object>} PlanningResponse with result and recommendations
    */
   async calculatePlanning(input) {
-    const response = await fetch(`${API_URL}/api/infrastructure/planning`, {
+    const response = await fetch(`${API_URL}/api/v1/infrastructure/planning`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(input),


### PR DESCRIPTION
## Summary

Updates all frontend API calls to use the versioned `/api/v1/` endpoint prefix introduced in PR #43.

- Updated 7 endpoints across 2 files to use `/api/v1/` prefix
- All frontend tests pass (220 tests)
- No linting errors

## Changes

### `frontend/src/TASCapacityAnalyzer.jsx`
- `/api/dashboard` → `/api/v1/dashboard`

### `frontend/src/services/scenarioApi.js`
- `/api/infrastructure` → `/api/v1/infrastructure`
- `/api/infrastructure/manual` → `/api/v1/infrastructure/manual`
- `/api/infrastructure/state` → `/api/v1/infrastructure/state`
- `/api/infrastructure/status` → `/api/v1/infrastructure/status`
- `/api/infrastructure/planning` → `/api/v1/infrastructure/planning`
- `/api/scenario/compare` → `/api/v1/scenario/compare`

## Test plan

- [x] Run `bun run test` - all 220 tests pass
- [x] Run `bun run lint` - no errors
- [x] Manual verification: Start backend and frontend, verify dashboard loads and scenario analysis works

Closes #46

## Related

- PR #43: Backend API refactoring (introduced versioned endpoints)
- PR #48: CLI API client updated to use versioned endpoints