### PR TITLE
Refactor JWKS error handling to use sentinel errors

### DIFF
--- a/backend/services/jwks_test.go
+++ b/backend/services/jwks_test.go
@@ -13,6 +13,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"hash"
 	"net/http"
 	"net/http/httptest"
@@ -634,8 +635,13 @@ func TestVerifyJWT_UnknownKeyID(t *testing.T) {
 		t.Fatal("expected error for unknown key ID, got nil")
 	}
 
-	if !strings.Contains(err.Error(), "unknown-key-id") || !strings.Contains(err.Error(), "key") {
-		t.Errorf("expected error to mention unknown key ID, got: %v", err)
+	if !errors.Is(err, ErrUnknownKeyID) {
+		t.Errorf("expected error to wrap ErrUnknownKeyID, got: %v", err)
+	}
+
+	// The error message should still include the specific key ID for debugging
+	if !strings.Contains(err.Error(), "unknown-key-id") {
+		t.Errorf("expected error to mention the specific key ID, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Replace fragile `strings.Contains(err.Error(), "unknown key ID")` with `errors.Is(err, ErrUnknownKeyID)` in `VerifyAndParse`
- Add exported `ErrUnknownKeyID` sentinel error at package level
- Wrap sentinel in `verifyJWT` via `fmt.Errorf("%w: ...")` so the specific key ID is still available for debugging

## Test plan

- [x] `TestVerifyJWT_UnknownKeyID` updated to assert `errors.Is(err, ErrUnknownKeyID)`
- [x] `TestJWKSClient_VerifyAndParse_RefreshOnUnknownKey` passes (refresh-on-unknown-key path)
- [x] Full services test suite (103 tests) passes

Closes #102