### PR TITLE
Add context propagation to CF and LogCache client methods

### DIFF
--- a/backend/handlers/health.go
+++ b/backend/handlers/health.go
@@ -53,14 +53,15 @@ func (h *Handler) Dashboard(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Authenticate with CF API
-	if err := h.cfClient.Authenticate(); err != nil {
+	ctx := r.Context()
+	if err := h.cfClient.Authenticate(ctx); err != nil {
 		slog.Error("CF API authentication failed", "error", err)
 		h.writeError(w, "Authentication service temporarily unavailable", http.StatusInternalServerError)
 		return
 	}
 
 	// Fetch apps from CF API
-	apps, err := h.cfClient.GetApps()
+	apps, err := h.cfClient.GetApps(ctx)
 	if err != nil {
 		slog.Error("CF API GetApps failed", "error", err)
 		h.writeError(w, "Failed to retrieve application data", http.StatusInternalServerError)
@@ -69,7 +70,7 @@ func (h *Handler) Dashboard(w http.ResponseWriter, r *http.Request) {
 	resp.Apps = apps
 
 	// Fetch isolation segments from CF API
-	segments, err := h.cfClient.GetIsolationSegments()
+	segments, err := h.cfClient.GetIsolationSegments(ctx)
 	if err != nil {
 		slog.Error("CF API GetIsolationSegments failed", "error", err)
 		h.writeError(w, "Failed to retrieve isolation segment data", http.StatusInternalServerError)

--- a/backend/services/cfapi.go
+++ b/backend/services/cfapi.go
@@ -4,6 +4,7 @@
 package services
 
 import (
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
@@ -42,9 +43,13 @@ func NewCFClient(apiURL, username, password string, skipSSLValidation bool) *CFC
 	}
 }
 
-func (c *CFClient) Authenticate() error {
+func (c *CFClient) Authenticate(ctx context.Context) error {
 	// Get UAA URL from CF API info
-	infoResp, err := c.client.Get(c.apiURL + "/v3/info")
+	infoReq, err := http.NewRequestWithContext(ctx, "GET", c.apiURL+"/v3/info", nil)
+	if err != nil {
+		return fmt.Errorf("failed to create CF info request: %w", err)
+	}
+	infoResp, err := c.client.Do(infoReq)
 	if err != nil {
 		return fmt.Errorf("failed to get CF info: %w", err)
 	}
@@ -75,7 +80,7 @@ func (c *CFClient) Authenticate() error {
 	data.Set("username", c.username)
 	data.Set("password", c.password)
 
-	req, err := http.NewRequest("POST", uaaURL+"/oauth/token", strings.NewReader(data.Encode()))
+	req, err := http.NewRequestWithContext(ctx, "POST", uaaURL+"/oauth/token", strings.NewReader(data.Encode()))
 	if err != nil {
 		return fmt.Errorf("failed to create auth request: %w", err)
 	}
@@ -112,12 +117,12 @@ func (c *CFClient) Authenticate() error {
 }
 
 // doAuthenticatedRequest performs an HTTP request with the CF API token
-func (c *CFClient) doAuthenticatedRequest(method, path string) (*http.Response, error) {
+func (c *CFClient) doAuthenticatedRequest(ctx context.Context, method, path string) (*http.Response, error) {
 	if c.token == "" {
 		return nil, fmt.Errorf("not authenticated: call Authenticate() first")
 	}
 
-	req, err := http.NewRequest(method, c.apiURL+path, nil)
+	req, err := http.NewRequestWithContext(ctx, method, c.apiURL+path, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -140,7 +145,7 @@ func (c *CFClient) doAuthenticatedRequest(method, path string) (*http.Response, 
 }
 
 // GetApps fetches all apps from CF API v3 with pagination
-func (c *CFClient) GetApps() ([]models.App, error) {
+func (c *CFClient) GetApps(ctx context.Context) ([]models.App, error) {
 	start := time.Now()
 	var apps []models.App
 	var pageCount int
@@ -148,7 +153,7 @@ func (c *CFClient) GetApps() ([]models.App, error) {
 
 	for nextURL != "" {
 		pageCount++
-		resp, err := c.doAuthenticatedRequest("GET", nextURL)
+		resp, err := c.doAuthenticatedRequest(ctx, "GET", nextURL)
 		if err != nil {
 			return nil, err
 		}
@@ -180,7 +185,7 @@ func (c *CFClient) GetApps() ([]models.App, error) {
 
 		// Fetch processes for each app to get memory, disk, and instance info
 		for _, resource := range result.Resources {
-			processes, err := c.getAppProcesses(resource.GUID)
+			processes, err := c.getAppProcesses(ctx, resource.GUID)
 			if err != nil {
 				return nil, err
 			}
@@ -196,7 +201,7 @@ func (c *CFClient) GetApps() ([]models.App, error) {
 			// Try to get actual memory from Log Cache
 			totalActualMB := totalRequestedMB // Default to requested
 			if c.logCache != nil && totalInstances > 0 {
-				metrics, err := c.logCache.GetAppMemoryMetrics(resource.GUID)
+				metrics, err := c.logCache.GetAppMemoryMetrics(ctx, resource.GUID)
 				if err == nil && metrics.MemoryBytesAvg > 0 {
 					// Convert bytes to MB
 					totalActualMB = int(metrics.MemoryBytesAvg / (1024 * 1024))
@@ -208,7 +213,7 @@ func (c *CFClient) GetApps() ([]models.App, error) {
 			}
 
 			// Get isolation segment for the space
-			isoSegName, err := c.getSpaceIsolationSegment(resource.Relationships.Space.Data.GUID)
+			isoSegName, err := c.getSpaceIsolationSegment(ctx, resource.Relationships.Space.Data.GUID)
 			if err != nil || isoSegName == "" {
 				// Apps without explicit isolation segment run on "default"
 				isoSegName = "default"
@@ -243,7 +248,7 @@ func (c *CFClient) GetApps() ([]models.App, error) {
 }
 
 // getAppProcesses fetches process information for an app
-func (c *CFClient) getAppProcesses(appGUID string) ([]struct {
+func (c *CFClient) getAppProcesses(ctx context.Context, appGUID string) ([]struct {
 	Type      string `json:"type"`
 	Instances int    `json:"instances"`
 	MemoryMB  int    `json:"memory_in_mb"`
@@ -252,7 +257,7 @@ func (c *CFClient) getAppProcesses(appGUID string) ([]struct {
 	if err := ValidateGUID(appGUID); err != nil {
 		return nil, fmt.Errorf("invalid app GUID: %w", err)
 	}
-	resp, err := c.doAuthenticatedRequest("GET", "/v3/apps/"+appGUID+"/processes")
+	resp, err := c.doAuthenticatedRequest(ctx, "GET", "/v3/apps/"+appGUID+"/processes")
 	if err != nil {
 		return nil, err
 	}
@@ -275,11 +280,11 @@ func (c *CFClient) getAppProcesses(appGUID string) ([]struct {
 }
 
 // getSpaceIsolationSegment fetches the isolation segment name for a space
-func (c *CFClient) getSpaceIsolationSegment(spaceGUID string) (string, error) {
+func (c *CFClient) getSpaceIsolationSegment(ctx context.Context, spaceGUID string) (string, error) {
 	if err := ValidateGUID(spaceGUID); err != nil {
 		return "", fmt.Errorf("invalid space GUID: %w", err)
 	}
-	resp, err := c.doAuthenticatedRequest("GET", "/v3/spaces/"+spaceGUID+"/relationships/isolation_segment")
+	resp, err := c.doAuthenticatedRequest(ctx, "GET", "/v3/spaces/"+spaceGUID+"/relationships/isolation_segment")
 	if err != nil {
 		return "", err
 	}
@@ -306,7 +311,7 @@ func (c *CFClient) getSpaceIsolationSegment(spaceGUID string) (string, error) {
 	}
 
 	// Fetch the isolation segment name
-	segResp, err := c.doAuthenticatedRequest("GET", "/v3/isolation_segments/"+result.Data.GUID)
+	segResp, err := c.doAuthenticatedRequest(ctx, "GET", "/v3/isolation_segments/"+result.Data.GUID)
 	if err != nil {
 		return "", err
 	}
@@ -324,12 +329,12 @@ func (c *CFClient) getSpaceIsolationSegment(spaceGUID string) (string, error) {
 }
 
 // GetIsolationSegments fetches all isolation segments from CF API v3
-func (c *CFClient) GetIsolationSegments() ([]models.IsolationSegment, error) {
+func (c *CFClient) GetIsolationSegments(ctx context.Context) ([]models.IsolationSegment, error) {
 	var segments []models.IsolationSegment
 	nextURL := "/v3/isolation_segments?per_page=100"
 
 	for nextURL != "" {
-		resp, err := c.doAuthenticatedRequest("GET", nextURL)
+		resp, err := c.doAuthenticatedRequest(ctx, "GET", nextURL)
 		if err != nil {
 			return nil, err
 		}

--- a/backend/services/cfapi_test.go
+++ b/backend/services/cfapi_test.go
@@ -1,10 +1,12 @@
 package services
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestCFClient_Authenticate(t *testing.T) {
@@ -36,7 +38,7 @@ func TestCFClient_Authenticate(t *testing.T) {
 
 	client := NewCFClient(cfServer.URL, "admin", "secret", true)
 
-	if err := client.Authenticate(); err != nil {
+	if err := client.Authenticate(context.Background()); err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
 
@@ -162,7 +164,7 @@ func TestCFClient_GetApps(t *testing.T) {
 	client := NewCFClient(server.URL, "admin", "secret", true)
 	client.token = "test-token"
 
-	apps, err := client.GetApps()
+	apps, err := client.GetApps(context.Background())
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -253,7 +255,7 @@ func TestCFClient_GetIsolationSegments(t *testing.T) {
 	client := NewCFClient(server.URL, "admin", "secret", true)
 	client.token = "test-token"
 
-	segments, err := client.GetIsolationSegments()
+	segments, err := client.GetIsolationSegments(context.Background())
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -288,7 +290,7 @@ func TestCFClient_GetApps_Unauthenticated(t *testing.T) {
 	client := NewCFClient(server.URL, "admin", "secret", true)
 	// Don't set token
 
-	_, err := client.GetApps()
+	_, err := client.GetApps(context.Background())
 	if err == nil {
 		t.Error("Expected error for unauthenticated request")
 	}
@@ -306,11 +308,116 @@ func TestCFClient_GetIsolationSegments_Unauthenticated(t *testing.T) {
 	client := NewCFClient(server.URL, "admin", "secret", true)
 	// Don't set token
 
-	_, err := client.GetIsolationSegments()
+	_, err := client.GetIsolationSegments(context.Background())
 	if err == nil {
 		t.Error("Expected error for unauthenticated request")
 	}
 	if !strings.Contains(err.Error(), "not authenticated") {
 		t.Errorf("Expected 'not authenticated' error, got %v", err)
+	}
+}
+
+func TestCFClient_Authenticate_CancelledContext(t *testing.T) {
+	// Server that responds slowly to simulate a real API
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/v3/info" {
+			w.Write([]byte(`{"links":{"login":{"href":"` + "http://localhost:0" + `"}}}`))
+		}
+	}))
+	defer server.Close()
+
+	client := NewCFClient(server.URL, "admin", "secret", true)
+
+	// Cancel context before the call
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := client.Authenticate(ctx)
+	if err == nil {
+		t.Fatal("Expected error when context is cancelled, got nil")
+	}
+	if !strings.Contains(err.Error(), "context canceled") {
+		t.Errorf("Expected context canceled error, got: %v", err)
+	}
+}
+
+func TestCFClient_GetApps_CancelledContext(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"resources":[],"pagination":{"next":null}}`))
+	}))
+	defer server.Close()
+
+	client := NewCFClient(server.URL, "admin", "secret", true)
+	client.token = "test-token"
+
+	// Cancel context before the call
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := client.GetApps(ctx)
+	if err == nil {
+		t.Fatal("Expected error when context is cancelled, got nil")
+	}
+	if !strings.Contains(err.Error(), "context canceled") {
+		t.Errorf("Expected context canceled error, got: %v", err)
+	}
+}
+
+func TestCFClient_GetIsolationSegments_CancelledContext(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"resources":[],"pagination":{"next":null}}`))
+	}))
+	defer server.Close()
+
+	client := NewCFClient(server.URL, "admin", "secret", true)
+	client.token = "test-token"
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := client.GetIsolationSegments(ctx)
+	if err == nil {
+		t.Fatal("Expected error when context is cancelled, got nil")
+	}
+	if !strings.Contains(err.Error(), "context canceled") {
+		t.Errorf("Expected context canceled error, got: %v", err)
+	}
+}
+
+func TestCFClient_Authenticate_ContextTimeout(t *testing.T) {
+	// Server that delays longer than the context deadline
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(500 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/v3/info" {
+			w.Write([]byte(`{"links":{"login":{"href":"` + serverURL + `"}}}`))
+			return
+		}
+		if r.URL.Path == "/oauth/token" {
+			w.Write([]byte(`{"access_token":"test-token","token_type":"bearer"}`))
+			return
+		}
+	}))
+	defer server.Close()
+	serverURL = server.URL
+
+	client := NewCFClient(server.URL, "admin", "secret", true)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	err := client.Authenticate(ctx)
+	if err == nil {
+		t.Fatal("Expected error when context times out, got nil")
+	}
+	if !strings.Contains(err.Error(), "context deadline exceeded") {
+		t.Errorf("Expected context deadline exceeded error, got: %v", err)
 	}
 }

--- a/backend/services/logcache.go
+++ b/backend/services/logcache.go
@@ -4,6 +4,7 @@
 package services
 
 import (
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
@@ -72,7 +73,7 @@ func (l *LogCacheClient) SetToken(token string) {
 }
 
 // GetAppMemoryMetrics fetches memory metrics for a specific app
-func (l *LogCacheClient) GetAppMemoryMetrics(appGUID string) (*AppMetrics, error) {
+func (l *LogCacheClient) GetAppMemoryMetrics(ctx context.Context, appGUID string) (*AppMetrics, error) {
 	if l.token == "" {
 		return nil, fmt.Errorf("not authenticated")
 	}
@@ -82,7 +83,7 @@ func (l *LogCacheClient) GetAppMemoryMetrics(appGUID string) (*AppMetrics, error
 	endpoint := fmt.Sprintf("%s/api/v1/read/%s?envelope_types=GAUGE&limit=100",
 		l.logCacheURL, appGUID)
 
-	req, err := http.NewRequest("GET", endpoint, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -146,7 +147,7 @@ func (l *LogCacheClient) GetAppMemoryMetrics(appGUID string) (*AppMetrics, error
 }
 
 // GetAppMemoryPromQL uses PromQL endpoint for more precise queries
-func (l *LogCacheClient) GetAppMemoryPromQL(appGUID string) (int64, error) {
+func (l *LogCacheClient) GetAppMemoryPromQL(ctx context.Context, appGUID string) (int64, error) {
 	if l.token == "" {
 		return 0, fmt.Errorf("not authenticated")
 	}
@@ -155,7 +156,7 @@ func (l *LogCacheClient) GetAppMemoryPromQL(appGUID string) (int64, error) {
 	query := url.QueryEscape(fmt.Sprintf(`avg_over_time(memory{source_id="%s"}[5m])`, appGUID))
 	endpoint := fmt.Sprintf("%s/api/v1/promql?query=%s", l.logCacheURL, query)
 
-	req, err := http.NewRequest("GET", endpoint, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
 	if err != nil {
 		return 0, fmt.Errorf("failed to create request: %w", err)
 	}


### PR DESCRIPTION
## Summary

Closes #47

- All `CFClient` methods (`Authenticate`, `GetApps`, `GetIsolationSegments`, and internal helpers) now accept `context.Context` and use `http.NewRequestWithContext` so timeouts and cancellation propagate into HTTP requests
- `LogCacheClient` methods (`GetAppMemoryMetrics`, `GetAppMemoryPromQL`) updated with the same pattern
- Handler callers (`Dashboard`, `enrichWithCFAppData`, `GetInfrastructureApps`) pass `r.Context()` or the existing handler context through to CF/LogCache methods
- Removed redundant manual `ctx.Err()` checks between CF calls in `enrichWithCFAppData` since context now propagates into the requests themselves

## Test plan

- [x] 4 new tests verify context cancellation and timeout behavior (`TestCFClient_Authenticate_CancelledContext`, `TestCFClient_GetApps_CancelledContext`, `TestCFClient_GetIsolationSegments_CancelledContext`, `TestCFClient_Authenticate_ContextTimeout`)
- [x] All existing tests updated to pass `context.Background()` and continue to pass
- [x] Full backend test suite passes (`make backend-test`)
- [x] Linting passes (`make lint`)